### PR TITLE
Add basic algorithm tests and instructions

### DIFF
--- a/docs/testing.md
+++ b/docs/testing.md
@@ -1,0 +1,11 @@
+# Testing
+
+Aby zbudować i uruchomić testy dla algorytmów:
+
+```bash
+cd tests
+make
+make test
+```
+
+Polecenie `make` kompiluje testy dla algorytmów merge sort, BFS/DFS oraz problemu plecakowego, a `make test` je uruchamia.

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -1,0 +1,19 @@
+CXX=g++
+CXXFLAGS=-std=c++17 -Wall -Wextra -pedantic
+
+TESTS=test_merge_sort test_graph_search test_knapsack
+
+all: $(TESTS)
+
+$(TESTS): %: %.cpp
+	$(CXX) $(CXXFLAGS) $< -o $@
+
+test: $(TESTS)
+	@./test_merge_sort
+	@./test_graph_search
+	@./test_knapsack
+
+clean:
+	rm -f $(TESTS)
+
+.PHONY: all test clean

--- a/tests/test_graph_search.cpp
+++ b/tests/test_graph_search.cpp
@@ -1,0 +1,56 @@
+#include <vector>
+#include <queue>
+#include <cassert>
+
+std::vector<int> bfs(const std::vector<std::vector<int>>& graph, int start) {
+    std::vector<int> order;
+    std::vector<bool> visited(graph.size(), false);
+    std::queue<int> q;
+    q.push(start);
+    visited[start] = true;
+    while (!q.empty()) {
+        int v = q.front();
+        q.pop();
+        order.push_back(v);
+        for (int u : graph[v]) {
+            if (!visited[u]) {
+                visited[u] = true;
+                q.push(u);
+            }
+        }
+    }
+    return order;
+}
+
+void dfsRec(const std::vector<std::vector<int>>& graph, int v,
+            std::vector<bool>& visited, std::vector<int>& order) {
+    visited[v] = true;
+    order.push_back(v);
+    for (int u : graph[v]) {
+        if (!visited[u])
+            dfsRec(graph, u, visited, order);
+    }
+}
+
+std::vector<int> dfs(const std::vector<std::vector<int>>& graph, int start) {
+    std::vector<int> order;
+    std::vector<bool> visited(graph.size(), false);
+    dfsRec(graph, start, visited, order);
+    return order;
+}
+
+int main() {
+    std::vector<std::vector<int>> g = {
+        {1, 2}, // 0
+        {0, 3}, // 1
+        {0, 3}, // 2
+        {1, 2}  // 3
+    };
+    auto bfsOrder = bfs(g, 0);
+    auto dfsOrder = dfs(g, 0);
+    std::vector<int> expectedBfs = {0, 1, 2, 3};
+    std::vector<int> expectedDfs = {0, 1, 3, 2};
+    assert(bfsOrder == expectedBfs);
+    assert(dfsOrder == expectedDfs);
+    return 0;
+}

--- a/tests/test_knapsack.cpp
+++ b/tests/test_knapsack.cpp
@@ -1,0 +1,26 @@
+#include <vector>
+#include <algorithm>
+#include <cassert>
+
+int knapsack(int W, const std::vector<int>& weights, const std::vector<int>& values) {
+    int n = weights.size();
+    std::vector<std::vector<int>> dp(n + 1, std::vector<int>(W + 1, 0));
+    for (int i = 1; i <= n; ++i) {
+        for (int w = 0; w <= W; ++w) {
+            dp[i][w] = dp[i - 1][w];
+            if (weights[i - 1] <= w) {
+                dp[i][w] = std::max(dp[i][w], dp[i - 1][w - weights[i - 1]] + values[i - 1]);
+            }
+        }
+    }
+    return dp[n][W];
+}
+
+int main() {
+    std::vector<int> weights = {2, 3, 4, 5};
+    std::vector<int> values  = {3, 4, 5, 6};
+    int capacity = 5;
+    int result = knapsack(capacity, weights, values);
+    assert(result == 7);
+    return 0;
+}

--- a/tests/test_merge_sort.cpp
+++ b/tests/test_merge_sort.cpp
@@ -1,0 +1,31 @@
+#include <vector>
+#include <functional>
+#include <algorithm>
+#include <cassert>
+
+void mergeSort(std::vector<int>& arr) {
+    if (arr.size() <= 1) return;
+    std::vector<int> tmp(arr.size());
+    std::function<void(int,int)> rec = [&](int l, int r) {
+        if (l >= r) return;
+        int m = (l + r) / 2;
+        rec(l, m);
+        rec(m + 1, r);
+        int i = l, j = m + 1, k = l;
+        while (i <= m && j <= r) {
+            if (arr[i] < arr[j]) tmp[k++] = arr[i++];
+            else tmp[k++] = arr[j++];
+        }
+        while (i <= m) tmp[k++] = arr[i++];
+        while (j <= r) tmp[k++] = arr[j++];
+        for (int t = l; t <= r; ++t) arr[t] = tmp[t];
+    };
+    rec(0, arr.size() - 1);
+}
+
+int main() {
+    std::vector<int> data = {5, 2, 9, 1, 5, 6};
+    mergeSort(data);
+    assert(std::is_sorted(data.begin(), data.end()));
+    return 0;
+}


### PR DESCRIPTION
## Summary
- add simple C++ tests for merge sort, BFS/DFS traversal, and knapsack DP
- provide Makefile-based test harness under `tests/`
- document how to build and run tests in `docs/testing.md`

## Testing
- `cd tests && make clean && make && ./test_merge_sort && ./test_graph_search && ./test_knapsack`


------
https://chatgpt.com/codex/tasks/task_e_68b1aca887a08322bab17a4aa164b84c