### PR TITLE
Add KMP and Boyer–Moore string matching algorithms

### DIFF
--- a/string_matching/boyer_moore.c
+++ b/string_matching/boyer_moore.c
@@ -1,0 +1,22 @@
+#include "boyer_moore_c.h"
+#include <string.h>
+
+int boyer_moore_search(const char *pattern, const char *text) {
+    size_t m = strlen(pattern);
+    size_t n = strlen(text);
+    if (m == 0) return 0;
+    int bad[256];
+    for (int i = 0; i < 256; ++i) bad[i] = -1;
+    for (size_t i = 0; i < m; ++i) bad[(unsigned char)pattern[i]] = (int)i;
+    size_t s = 0;
+    while (s <= n - m) {
+        int j = (int)m - 1;
+        while (j >= 0 && pattern[j] == text[s + j]) --j;
+        if (j < 0) return (int)s;
+        unsigned char c = (unsigned char)text[s + j];
+        int shift = j - bad[c];
+        if (shift < 1) shift = 1;
+        s += shift;
+    }
+    return -1;
+}

--- a/string_matching/boyer_moore.cpp
+++ b/string_matching/boyer_moore.cpp
@@ -1,0 +1,31 @@
+#include "boyer_moore.h"
+#include <array>
+#include <algorithm>
+
+namespace boyer_moore {
+int search(const std::string &pattern, const std::string &text) {
+    if (pattern.empty()) return 0;
+    std::array<int, 256> bad;
+    bad.fill(-1);
+    for (size_t i = 0; i < pattern.size(); ++i) {
+        bad[static_cast<unsigned char>(pattern[i])] = static_cast<int>(i);
+    }
+    size_t m = pattern.size();
+    size_t n = text.size();
+    size_t s = 0;
+    while (s <= n - m) {
+        int j = static_cast<int>(m - 1);
+        while (j >= 0 && pattern[j] == text[s + j]) {
+            --j;
+        }
+        if (j < 0) {
+            return static_cast<int>(s);
+        }
+        unsigned char c = static_cast<unsigned char>(text[s + j]);
+        int shift = std::max(1, j - bad[c]);
+        s += shift;
+    }
+    return -1;
+}
+}
+

--- a/string_matching/boyer_moore.h
+++ b/string_matching/boyer_moore.h
@@ -1,0 +1,7 @@
+#pragma once
+#include <string>
+
+namespace boyer_moore {
+int search(const std::string &pattern, const std::string &text);
+}
+

--- a/string_matching/boyer_moore.zig
+++ b/string_matching/boyer_moore.zig
@@ -1,0 +1,25 @@
+const std = @import("std");
+
+pub fn search(pattern: []const u8, text: []const u8) ?usize {
+    if (pattern.len == 0) return 0;
+    if (pattern.len > text.len) return null;
+    var bad: [256]isize = undefined;
+    for (bad) |*b| b.* = -1;
+    var i: usize = 0;
+    while (i < pattern.len) : (i += 1) {
+        bad[pattern[i]] = @as(isize, @intCast(i));
+    }
+    var s: usize = 0;
+    while (s + pattern.len <= text.len) {
+        var j: isize = @as(isize, @intCast(pattern.len)) - 1;
+        while (j >= 0 and pattern[@as(usize, @intCast(j))] == text[s + @as(usize, @intCast(j))]) {
+            j -= 1;
+        }
+        if (j < 0) return s;
+        const c = text[s + @as(usize, @intCast(j))];
+        var shift: isize = j - bad[c];
+        if (shift < 1) shift = 1;
+        s += @as(usize, @intCast(shift));
+    }
+    return null;
+}

--- a/string_matching/boyer_moore_c.h
+++ b/string_matching/boyer_moore_c.h
@@ -1,0 +1,16 @@
+#ifndef BOYER_MOORE_C_H
+#define BOYER_MOORE_C_H
+
+#include <stddef.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+int boyer_moore_search(const char *pattern, const char *text);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // BOYER_MOORE_C_H

--- a/string_matching/kmp.c
+++ b/string_matching/kmp.c
@@ -1,0 +1,43 @@
+#include "kmp_c.h"
+#include <stdlib.h>
+#include <string.h>
+
+static void build_lps(const char *pattern, int *lps, size_t m) {
+    size_t len = 0;
+    lps[0] = 0;
+    for (size_t i = 1; i < m;) {
+        if (pattern[i] == pattern[len]) {
+            lps[i++] = ++len;
+        } else if (len != 0) {
+            len = lps[len - 1];
+        } else {
+            lps[i++] = 0;
+        }
+    }
+}
+
+int kmp_search(const char *pattern, const char *text) {
+    size_t m = strlen(pattern);
+    size_t n = strlen(text);
+    if (m == 0) return 0;
+    int *lps = (int*)malloc(sizeof(int) * m);
+    if (!lps) return -1;
+    build_lps(pattern, lps, m);
+    size_t i = 0, j = 0;
+    while (i < n) {
+        if (pattern[j] == text[i]) {
+            ++i; ++j;
+            if (j == m) {
+                free(lps);
+                return (int)(i - j);
+            }
+        } else if (j != 0) {
+            j = lps[j - 1];
+        } else {
+            ++i;
+        }
+    }
+    free(lps);
+    return -1;
+}
+

--- a/string_matching/kmp.cpp
+++ b/string_matching/kmp.cpp
@@ -1,0 +1,44 @@
+#include "kmp.h"
+#include <vector>
+
+namespace kmp {
+namespace {
+std::vector<int> buildLPS(const std::string &pattern) {
+    std::vector<int> lps(pattern.size());
+    int len = 0;
+    lps[0] = 0;
+    for (size_t i = 1; i < pattern.size(); ) {
+        if (pattern[i] == pattern[len]) {
+            lps[i++] = ++len;
+        } else if (len != 0) {
+            len = lps[len - 1];
+        } else {
+            lps[i++] = 0;
+        }
+    }
+    return lps;
+}
+}
+
+int search(const std::string &pattern, const std::string &text) {
+    if (pattern.empty()) return 0;
+    auto lps = buildLPS(pattern);
+    size_t i = 0; // index for text
+    size_t j = 0; // index for pattern
+    while (i < text.size()) {
+        if (pattern[j] == text[i]) {
+            ++i;
+            ++j;
+            if (j == pattern.size()) {
+                return static_cast<int>(i - j);
+            }
+        } else if (j != 0) {
+            j = lps[j - 1];
+        } else {
+            ++i;
+        }
+    }
+    return -1;
+}
+}
+

--- a/string_matching/kmp.h
+++ b/string_matching/kmp.h
@@ -1,0 +1,7 @@
+#pragma once
+#include <string>
+
+namespace kmp {
+int search(const std::string &pattern, const std::string &text);
+}
+

--- a/string_matching/kmp.zig
+++ b/string_matching/kmp.zig
@@ -1,0 +1,39 @@
+const std = @import("std");
+
+pub fn search(pattern: []const u8, text: []const u8) ?usize {
+    if (pattern.len == 0) return 0;
+    var allocator = std.heap.page_allocator;
+    var lps = allocator.alloc(usize, pattern.len) catch return null;
+    defer allocator.free(lps);
+
+    var len: usize = 0;
+    lps[0] = 0;
+    var i: usize = 1;
+    while (i < pattern.len) {
+        if (pattern[i] == pattern[len]) {
+            len += 1;
+            lps[i] = len;
+            i += 1;
+        } else if (len != 0) {
+            len = lps[len - 1];
+        } else {
+            lps[i] = 0;
+            i += 1;
+        }
+    }
+
+    var ti: usize = 0;
+    var pj: usize = 0;
+    while (ti < text.len) {
+        if (pattern[pj] == text[ti]) {
+            ti += 1;
+            pj += 1;
+            if (pj == pattern.len) return ti - pj;
+        } else if (pj != 0) {
+            pj = lps[pj - 1];
+        } else {
+            ti += 1;
+        }
+    }
+    return null;
+}

--- a/string_matching/kmp_c.h
+++ b/string_matching/kmp_c.h
@@ -1,0 +1,16 @@
+#ifndef KMP_C_H
+#define KMP_C_H
+
+#include <stddef.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+int kmp_search(const char *pattern, const char *text);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // KMP_C_H


### PR DESCRIPTION
## Summary
- implement KMP string search in C, C++, and Zig with reusable headers and modules
- add Boyer–Moore variant across the same languages
- provide exported interfaces for use throughout the project

## Testing
- `g++ -std=c++17 -c string_matching/kmp.cpp`
- `g++ -std=c++17 -c string_matching/boyer_moore.cpp`
- `gcc -std=c99 -c string_matching/kmp.c`
- `gcc -std=c99 -c string_matching/boyer_moore.c`
- `/tmp/zig-linux-x86_64-0.11.0/zig build-obj string_matching/kmp.zig`
- `/tmp/zig-linux-x86_64-0.11.0/zig build-obj string_matching/boyer_moore.zig`


------
https://chatgpt.com/codex/tasks/task_e_68b1df30925483228f5bef1e51ca9b2f